### PR TITLE
[PR] Allow filtering of "submit for review" capability

### DIFF
--- a/admin/duplicate-post.php
+++ b/admin/duplicate-post.php
@@ -276,7 +276,7 @@ class DuplicatePost{
 
 	    if($original_post_id){
 	      $label = "Update";
-	  	  $allow_submit_for_review = DuplicatePost::duplicate_post_is_current_user_allowed_to_copy();
+	  	  $allow_submit_for_review = apply_filters( 'duplicate_post_allow_submit_for_review', DuplicatePost::duplicate_post_is_current_user_allowed_to_copy(), $original_post_id );
 	      $allow_merge_back = DuplicatePost::duplicate_post_is_current_user_allowed_to_merge_back();
 
 	      $merge_label = "Merge back to Original Post";


### PR DESCRIPTION
In some cases, we may not want to include "submit for review" as part of our workflow in favor of that provided elsewhere. As this uses the same setting as "allowed to copy", it should have a filter for more granular control.
