### PR TITLE
When merging back, don't override original post date

### DIFF
--- a/admin/duplicate-post.php
+++ b/admin/duplicate-post.php
@@ -1169,10 +1169,14 @@ class DuplicatePost{
 			$new_post["ID"] = $to_post_id;
 		}
 
-		if($this->get_option('duplicate_post_copydate') == 1){
-			$new_post['post_date'] = $new_post_date =  $post_to_dup->post_date ;
-			$new_post['post_date_gmt'] = get_gmt_from_date($new_post_date);
-		}
+                if($this->get_option('duplicate_post_copydate') == 1 && empty( $to_post_id ) ){
+                        $new_post['post_date'] = $new_post_date =  $post_to_dup->post_date ;
+                        $new_post['post_date_gmt'] = get_gmt_from_date($new_post_date);
+                } else if( ! empty( $to_post_id ) ) {
+                        // We are merging back, do not override publish date
+                        $new_post['post_date'] = $new_post_date =  $to_post->post_date ;
+                        $new_post['post_date_gmt'] = get_gmt_from_date($new_post_date);
+                }
 
 		$new_post_id = wp_insert_post($new_post);
 		delete_post_meta($new_post_id, '_dp_original_backup');


### PR DESCRIPTION
When merging back to original post, original post date should not be overridden by duplicate post date. This is a big issue in editorial workflow and make difficult to properly track post updates. The proposed change fixes this issue by checking if we are merging post and then assigning post date to original.
